### PR TITLE
Launchpad: emit max_task_concurrency for ORB EC2 worker manager

### DIFF
--- a/docs/html_extra/launchpad/provisioner.js
+++ b/docs/html_extra/launchpad/provisioner.js
@@ -147,6 +147,10 @@ worker_manager_id = "${wm.id}"
 
       if (wm.type === "orb_aws_ec2") {
         var req = (wm.requirements || "").trim();
+        var inst = (window.SCALER_INSTANCES || []).find(function(i) { return i.type === wm.instanceType; }) || { price: 0 };
+        var orbDerivedCount = wm.capMode === "instances"
+          ? Math.max(0, wm.instanceCap || 0)
+          : Math.max(0, Math.floor((wm.budgetCap || 0) / (inst.price || 1)));
         block += `worker_scheduler_address = "${proto}://<PRIVATE_IP>:${sp}${wsSlash}"
 object_storage_address = "${proto}://<PRIVATE_IP>:${op}${wsSlash}"
 python_version = "${cfg.pythonVersion}"
@@ -154,6 +158,7 @@ requirements_txt = """
 ${req}
 """
 instance_type = "${wm.instanceType}"
+max_task_concurrency = ${orbDerivedCount}
 aws_region = "${cfg.region}"
 key_name = "scaler-key-${suffix}"
 subnet_id = "<SUBNET_ID>"


### PR DESCRIPTION
Mirror of finos/opengris-scaler#834. Base is `waterfall-optional-max-task-concurrency`; this PR shows only these changes.

## Summary

- Fixes the Launchpad config generator for ORB EC2: without this, `max_task_concurrency` was not emitted, causing the worker manager to default to `os.cpu_count()` on the Launchpad host.
- Derives the count from the cap mode: instance cap directly, or budget divided by instance price.
- Also fixes `configFromToml` round-trip: when loading an existing config, the ORB EC2 `max_task_concurrency` value is now used to populate `instanceCap` instead of defaulting to 4.

## Test plan

- [ ] Generate an ORB EC2 config in the Launchpad and verify `max_task_concurrency` appears with the correct value
- [ ] Load an existing config with `max_task_concurrency` set and verify `instanceCap` round-trips correctly