### PR TITLE
fix: report coordinator desired count in heartbeat to prevent missed scale-down

### DIFF
--- a/src/protocol/message.capnp
+++ b/src/protocol/message.capnp
@@ -90,9 +90,10 @@ struct WorkerHeartbeatEcho {
 }
 
 struct WorkerManagerHeartbeat {
-    maxTaskConcurrency @0 :UInt32;
-    capabilities @1 :List(CommonType.TaskCapability);
-    workerManagerID @2 :Data;
+    maxTaskConcurrency    @0 :UInt32;
+    capabilities          @1 :List(CommonType.TaskCapability);
+    workerManagerID       @2 :Data;
+    currentDesiredWorkers @3 :UInt32;
 }
 
 struct WorkerManagerHeartbeatEcho {

--- a/src/scaler/protocol/capnp.pyi
+++ b/src/scaler/protocol/capnp.pyi
@@ -237,6 +237,7 @@ class WorkerManagerHeartbeat(BaseMessage):
     maxTaskConcurrency: int
     capabilities: Any
     workerManagerID: bytes
+    currentDesiredWorkers: int
 
 class WorkerManagerHeartbeatEcho(BaseMessage): ...
 

--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/capability_scaling.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/capability_scaling.py
@@ -36,7 +36,7 @@ class CapabilityScalingPolicy(ScalingPolicy):
         tasks_by_capability = self._group_tasks_by_capability(information_snapshot)
         desired_per_capset = self._compute_desired_per_capset(tasks_by_capability, worker_manager_heartbeat)
         effective = effective_desired_for_manager(desired_per_capset, worker_manager_heartbeat.capabilities)
-        if effective == len(managed_worker_ids):
+        if effective == worker_manager_heartbeat.currentDesiredWorkers:
             return []
         return [build_set_desired_command(desired_per_capset)]
 

--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/vanilla.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/vanilla.py
@@ -32,7 +32,7 @@ class VanillaScalingPolicy(ScalingPolicy):
         desired = self._compute_desired_worker_count(information_snapshot, worker_manager_heartbeat, managed_worker_ids)
         desired_per_capset: List[Tuple[Dict[str, int], int]] = [({}, desired)]
         effective = effective_desired_for_manager(desired_per_capset, worker_manager_heartbeat.capabilities)
-        if effective == len(managed_worker_ids):
+        if effective == worker_manager_heartbeat.currentDesiredWorkers:
             return []
         return [build_set_desired_command(desired_per_capset)]
 

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
@@ -52,7 +52,7 @@ class WaterfallScalingPolicy(ScalingPolicy):
             rule, information_snapshot, worker_manager_heartbeat, worker_manager_snapshots
         )
         effective = effective_desired_for_manager(desired_per_capset, worker_manager_heartbeat.capabilities)
-        if effective == len(managed_worker_ids):
+        if effective == worker_manager_heartbeat.currentDesiredWorkers:
             return []
         return [build_set_desired_command(desired_per_capset)]
 

--- a/src/scaler/worker_manager_adapter/aws_hpc/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/aws_hpc/worker_manager.py
@@ -32,6 +32,9 @@ class BatchWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._units)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/aws_raw/ecs.py
+++ b/src/scaler/worker_manager_adapter/aws_raw/ecs.py
@@ -137,6 +137,9 @@ class ECSWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._units)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/baremetal/native.py
+++ b/src/scaler/worker_manager_adapter/baremetal/native.py
@@ -108,6 +108,9 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._workers)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def start_units(self, count: int) -> None:
         for _ in range(count):
             worker = self._create_worker()

--- a/src/scaler/worker_manager_adapter/capacity_coordinator.py
+++ b/src/scaler/worker_manager_adapter/capacity_coordinator.py
@@ -40,6 +40,10 @@ class CapacityCoordinator:
         self._reconcile_needed: asyncio.Event = asyncio.Event()
         self._stop: asyncio.Event = asyncio.Event()
 
+    @property
+    def desired_unit_count(self) -> int:
+        return self._desired_unit_count
+
     async def set_desired_unit_count(self, count: int) -> None:
         """Set the desired number of units and signal the reconcile task."""
         if count == self._desired_unit_count:

--- a/src/scaler/worker_manager_adapter/mixins.py
+++ b/src/scaler/worker_manager_adapter/mixins.py
@@ -77,6 +77,11 @@ class DeclarativeWorkerProvisioner(ABC):
         ...
 
     @abstractmethod
+    def desired_unit_count(self) -> int:
+        """Return the number of units currently desired by the coordinator."""
+        ...
+
+    @abstractmethod
     async def terminate(self) -> None:
         """Cancel the capacity coordinator and stop all running units."""
         ...

--- a/src/scaler/worker_manager_adapter/oci_hpc/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/oci_hpc/worker_manager.py
@@ -32,6 +32,9 @@ class OCIHPCWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._units)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/oci_raw/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/oci_raw/worker_manager.py
@@ -59,6 +59,9 @@ class OCIRawWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._instances)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
@@ -53,6 +53,9 @@ class ORBWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._units)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/symphony/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/symphony/worker_manager.py
@@ -42,6 +42,9 @@ class SymphonyWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._workers)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/worker_manager_runner.py
+++ b/src/scaler/worker_manager_adapter/worker_manager_runner.py
@@ -79,6 +79,8 @@ class WorkerManagerRunner:
                 maxTaskConcurrency=self._max_provisioner_units * self._workers_per_provisioner_unit,
                 capabilities=dict_to_capabilities(self._capabilities),
                 workerManagerID=self._worker_manager_id,
+                currentDesiredWorkers=self._worker_provisioner.desired_unit_count()
+                * self._workers_per_provisioner_unit,
             )
         )
 

--- a/tests/scheduler/test_scaling.py
+++ b/tests/scheduler/test_scaling.py
@@ -215,7 +215,7 @@ class TestVanillaScalingPolicy(unittest.TestCase):
         }
         managed = list(workers.keys())
         snapshot = InformationSnapshot(tasks={}, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", current_desired_workers=3)
 
         request = self._single_request(snapshot, heartbeat, managed)
 
@@ -235,12 +235,12 @@ class TestVanillaScalingPolicy(unittest.TestCase):
         self.assertEqual(request.taskConcurrency, 1)
 
     def test_balanced_ratio_skips_when_desired_equals_current(self):
-        """Task ratio in band keeps desired == current managed count -> no-op skip."""
+        """Task ratio in band keeps effective desired == currentDesiredWorkers -> no-op skip."""
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(15)}
         workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(5)}
         managed = list(workers.keys())
         snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", current_desired_workers=5)
 
         commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -252,19 +252,19 @@ class TestVanillaScalingPolicy(unittest.TestCase):
         managed = [WorkerID(b"w0"), WorkerID(b"w1")]
         workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=20) for wid in managed}
         snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=2)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=2, current_desired_workers=2)
 
         commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
-        # Ratio would say desired=3, cap clamps to 2, which equals current=2 -> skip.
+        # Ratio would say desired=3, cap clamps to 2, which equals currentDesiredWorkers=2 -> skip.
         self.assertEqual(commands, [])
 
 
 class TestNoOpSkip(unittest.TestCase):
-    """A command whose effective desired count matches the manager's current connected
-    worker count is a no-op for the worker manager. The scheduler skips emission for
-    such commands so it doesn't waste network traffic on commands that cannot change
-    anything (notably: when the manager is already at its config-given max)."""
+    """A command whose effective desired count matches the manager's currentDesiredWorkers
+    (as reported in the heartbeat) is a no-op. The scheduler skips emission so it doesn't
+    waste network traffic on commands that cannot change anything (notably: when the manager
+    is already at its config-given max)."""
 
     def setUp(self):
         setup_logger()
@@ -276,7 +276,7 @@ class TestNoOpSkip(unittest.TestCase):
         managed = [WorkerID(f"w{i}".encode()) for i in range(10)]
         workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=10) for wid in managed}
         snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10, current_desired_workers=10)
 
         commands = policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -298,16 +298,18 @@ class TestNoOpSkip(unittest.TestCase):
         self.assertEqual(requests[0].taskConcurrency, 2)
 
     def test_capability_at_cap_skips(self):
-        """Capability: ratio's per-capset desired equals current connected -> skip emission."""
+        """Capability: ratio's per-capset desired equals currentDesiredWorkers -> skip emission."""
         policy = CapabilityScalingPolicy()
-        # ceil(50/5) = 10 desired for gpu capset; clamp at cap=10; current connected = 10 -> no-op.
+        # ceil(50/5) = 10 desired for gpu capset; clamp at cap=10; currentDesiredWorkers=10 -> no-op.
         tasks = {}
         for _ in range(50):
             tid = TaskID.generate_task_id()
             tasks[tid] = _create_mock_task(tid, {"gpu": 1})
         managed = [WorkerID(f"w{i}".encode()) for i in range(10)]
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10, capabilities={"gpu": -1})
+        heartbeat = _create_worker_manager_heartbeat(
+            b"mgr", max_task_concurrency=10, capabilities={"gpu": -1}, current_desired_workers=10
+        )
 
         commands = policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -328,19 +330,19 @@ class TestNoOpSkip(unittest.TestCase):
         self.assertEqual(commands, [])
 
     def test_waterfall_at_cap_skips(self):
-        """Waterfall: when the manager is full per the priority chain and already has that
-        many workers connected, emission is skipped."""
+        """Waterfall: when the manager is full per the priority chain and its coordinator
+        already reflects that, emission is skipped."""
         from scaler.scheduler.controllers.policies.simple_policy.scaling.types import WorkerManagerSnapshot
         from scaler.scheduler.controllers.policies.waterfall_v1.scaling.types import WaterfallRule
         from scaler.scheduler.controllers.policies.waterfall_v1.scaling.waterfall import WaterfallScalingPolicy
 
         rules = [WaterfallRule(priority=1, worker_manager_id=b"mgr", max_task_concurrency=10)]
         policy = WaterfallScalingPolicy(rules)
-        # ceil(100/10) = 10; cap=10; manager has 10 connected -> effective 10 == current 10 -> skip.
+        # ceil(100/10) = 10; cap=10; coordinator desired=10 -> effective 10 == currentDesiredWorkers=10 -> skip.
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(100)}
         managed = [WorkerID(f"w{i}".encode()) for i in range(10)]
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10, current_desired_workers=10)
         manager_snapshots = {
             b"mgr": WorkerManagerSnapshot(
                 worker_manager_id=b"mgr", max_task_concurrency=10, worker_count=10, last_seen_s=0.0, capabilities={}
@@ -350,6 +352,23 @@ class TestNoOpSkip(unittest.TestCase):
         commands = policy.get_scaling_commands(snapshot, heartbeat, managed, manager_snapshots)
 
         self.assertEqual(commands, [])
+
+    def test_scale_down_not_suppressed_when_coordinator_desired_nonzero(self):
+        """Scale-down command must be emitted when the WM coordinator has desired>0 but
+        no workers have connected yet (e.g. EC2 instance still booting)."""
+        snapshot = InformationSnapshot(tasks={}, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", current_desired_workers=2)
+
+        vanilla_policy = VanillaScalingPolicy()
+        commands = vanilla_policy.get_scaling_commands(snapshot, heartbeat, [], {})
+        self.assertEqual(len(commands), 1)
+        requests = list(commands[0].setDesiredTaskConcurrencyRequests)
+        self.assertEqual(requests[0].taskConcurrency, 0)
+
+        capability_policy = CapabilityScalingPolicy()
+        commands_cap = capability_policy.get_scaling_commands(snapshot, heartbeat, [], {})
+        self.assertEqual(len(commands_cap), 1)
+        self.assertEqual(list(commands_cap[0].setDesiredTaskConcurrencyRequests), [])
 
 
 class TestCapabilityScalingPolicy(unittest.TestCase):
@@ -483,7 +502,7 @@ class TestVanillaDeclarativeEquivalents(unittest.TestCase):
         workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=0) for i in range(4)}
         managed = list(workers.keys())
         snapshot = InformationSnapshot(tasks={}, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", current_desired_workers=4)
 
         commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -515,7 +534,7 @@ class TestVanillaDeclarativeEquivalents(unittest.TestCase):
         workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(5)}
         managed = list(workers.keys())
         snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", current_desired_workers=5)
 
         commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -539,11 +558,11 @@ class TestCapabilityDeclarativeEquivalents(unittest.TestCase):
 
     def test_drain_capset_when_no_tasks(self):
         """With 3 connected workers and no tasks, the policy emits setDesired with an
-        empty request list -- effective desired (0) differs from current (3) so the manager
-        is told to drain (via extract_desired_count returning 0 for the empty list)."""
+        empty request list -- effective desired (0) differs from currentDesiredWorkers (3) so
+        the manager is told to drain (via extract_desired_count returning 0 for the empty list)."""
         managed = [WorkerID(f"w{i}".encode()) for i in range(3)]
         snapshot = InformationSnapshot(tasks={}, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": -1})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": -1}, current_desired_workers=3)
 
         commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -663,10 +682,16 @@ def _create_mock_worker_heartbeat(capabilities: dict, queued_tasks: int = 0) -> 
 
 
 def _create_worker_manager_heartbeat(
-    worker_manager_id: bytes, max_task_concurrency: int = 10, capabilities: Optional[Dict[str, int]] = None
+    worker_manager_id: bytes,
+    max_task_concurrency: int = 10,
+    capabilities: Optional[Dict[str, int]] = None,
+    current_desired_workers: int = 0,
 ) -> WorkerManagerHeartbeat:
     return WorkerManagerHeartbeat(
-        maxTaskConcurrency=max_task_concurrency, capabilities=capabilities or {}, workerManagerID=worker_manager_id
+        maxTaskConcurrency=max_task_concurrency,
+        capabilities=capabilities or {},
+        workerManagerID=worker_manager_id,
+        currentDesiredWorkers=current_desired_workers,
     )
 
 

--- a/tests/scheduler/test_waterfall_scaling.py
+++ b/tests/scheduler/test_waterfall_scaling.py
@@ -173,14 +173,14 @@ class TestWaterfallScalingPolicy(unittest.TestCase):
 
         # manager_b (lower priority) is told to drain to 0
         managed_b = [WorkerID(b"worker-3"), WorkerID(b"worker-4")]
-        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
+        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20, current_desired_workers=2)
         commands_b = policy.get_scaling_commands(snapshot, heartbeat_b, managed_b, manager_snapshots)
         self.assertEqual(len(commands_b), 1)
         self.assertEqual(_generic_request(commands_b[0]).taskConcurrency, 0)
 
-        # manager_a (higher priority) is NOT told to drain yet -- desired matches its current count
+        # manager_a (higher priority) is NOT told to drain yet -- desired matches currentDesiredWorkers
         managed_a = [WorkerID(b"worker-0"), WorkerID(b"worker-1"), WorkerID(b"worker-2")]
-        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
+        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10, current_desired_workers=3)
         commands_a = policy.get_scaling_commands(snapshot, heartbeat_a, managed_a, manager_snapshots)
         self.assertEqual(commands_a, [])
 
@@ -198,7 +198,7 @@ class TestWaterfallScalingPolicy(unittest.TestCase):
         }
 
         managed_a = [WorkerID(b"worker-0"), WorkerID(b"worker-1"), WorkerID(b"worker-2")]
-        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
+        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10, current_desired_workers=3)
         commands_a = policy.get_scaling_commands(snapshot, heartbeat_a, managed_a, manager_snapshots)
 
         # No lower-priority manager to wait on -- emit setDesired(0) to drain.
@@ -304,13 +304,27 @@ class TestWaterfallScalingPolicy(unittest.TestCase):
         }
 
         managed_b = [WorkerID(b"w0"), WorkerID(b"w1")]
-        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
+        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20, current_desired_workers=2)
         commands_b = policy.get_scaling_commands(snapshot, heartbeat_b, managed_b, manager_snapshots)
 
         # 5 tasks -> total_desired=1, absorbed by manager_a entirely -> manager_b's share=0;
         # but manager_b has 2 connected workers, so the command is not a no-op.
         self.assertEqual(len(commands_b), 1)
         self.assertEqual(_generic_request(commands_b[0]).taskConcurrency, 0)
+
+    def test_scale_down_not_suppressed_when_coordinator_desired_nonzero(self):
+        """Scale-down command must be emitted when the WM coordinator has desired>0 but
+        no workers have connected yet (e.g. EC2 instance still booting)."""
+        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10)]
+        policy = WaterfallScalingPolicy(rules)
+        snapshot = InformationSnapshot(tasks={}, workers={})
+        manager_snapshots = {b"manager_a": _create_manager_snapshot(b"manager_a")}
+        heartbeat = _create_worker_manager_heartbeat(b"manager_a", current_desired_workers=2)
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
+
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(_generic_request(commands[0]).taskConcurrency, 0)
 
 
 class TestWaterfallCapabilities(unittest.TestCase):
@@ -670,10 +684,16 @@ def _create_mock_worker_heartbeat(
 
 
 def _create_worker_manager_heartbeat(
-    worker_manager_id: bytes, max_task_concurrency: int = 10, capabilities: Optional[Dict[str, int]] = None
+    worker_manager_id: bytes,
+    max_task_concurrency: int = 10,
+    capabilities: Optional[Dict[str, int]] = None,
+    current_desired_workers: int = 0,
 ) -> WorkerManagerHeartbeat:
     return WorkerManagerHeartbeat(
-        maxTaskConcurrency=max_task_concurrency, capabilities=capabilities or {}, workerManagerID=worker_manager_id
+        maxTaskConcurrency=max_task_concurrency,
+        capabilities=capabilities or {},
+        workerManagerID=worker_manager_id,
+        currentDesiredWorkers=current_desired_workers,
     )
 
 


### PR DESCRIPTION
Mirror of finos/opengris-scaler#835. Base is `orb-ec2-max-task-concurrency`; this PR shows only these changes.

## Summary

- The scaling policies suppressed sending a `WorkerManagerCommand` when effective desired workers matched the number of connected workers. This caused scale-down to be skipped when a provisioner had `desired > 0` but workers hadn't connected yet (e.g. EC2 instance still booting), leaving orphaned instances indefinitely.
- Adds `currentDesiredWorkers` to `WorkerManagerHeartbeat` so the scheduler compares against the coordinator's actual desired state instead of the count of connected workers.
- All three policies (vanilla, capability, waterfall) and all seven provisioner implementations are updated.

## Test plan

- [ ] `test_scaling.py` and `test_waterfall_scaling.py` pass with updated assertions
- [ ] Verify scale-down is triggered when a provisioner reports `desired > 0` but no workers are connected